### PR TITLE
Remove unnecessary .postcss

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ gulp.task('webp', function () {
 gulp.task('css', function () {
     var processors = [
         autoprefixer,
-        webpcss.postcss
+        webpcss
     ];
     return gulp.src('./src/*.css')
         .pipe( postcss(processors) )


### PR DESCRIPTION
PostCSS check `.postcss` property automatically: https://github.com/postcss/postcss/blob/master/lib/postcss.js#L45
